### PR TITLE
Fix SCAM sample to be treeshakable

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -529,4 +529,7 @@
 <!-- * * * * * * * * * * End of Placeholder * * * * * * * * * * * -->
 <!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * -->
 
+<!-- IF YOU DE-COMMENT NEXT LINE YOU'LL FIND ONLY sc-scam1 IN YOUR BUNDLE main-xxx.js , 
+     BUT IF YOU DON'T USE EITHER SCAM COMPONENT, THEY WILL BE CORRECTLY TREESHAKED! -->
+<!--<app-sc-scam1></app-sc-scam1>-->
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 
 import { AppComponent } from './app.component';
 import { Feature1Module } from './feature1/feature1.module';
+import { SharedScamModule } from './shared-scam/shared-scam.module';
 
 @NgModule({
   declarations: [
@@ -11,6 +12,7 @@ import { Feature1Module } from './feature1/feature1.module';
   imports: [
     BrowserModule,
     Feature1Module,
+    SharedScamModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/shared-scam/sc-scam1/sc-scam1.component.ts
+++ b/src/app/shared-scam/sc-scam1/sc-scam1.component.ts
@@ -23,7 +23,6 @@ export class ScScam1Component implements OnInit {
 }
 
 @NgModule({
-  bootstrap: [ScScam1Component],
   declarations: [ScScam1Component],
   imports: [
     CommonModule,

--- a/src/app/shared-scam/sc-scam2/sc-scam2.component.ts
+++ b/src/app/shared-scam/sc-scam2/sc-scam2.component.ts
@@ -23,7 +23,6 @@ export class ScScam2Component implements OnInit {
 }
 
 @NgModule({
-  bootstrap: [ScScam2Component],
   declarations: [ScScam2Component],
   imports: [
     CommonModule,

--- a/src/app/shared-scam/shared-scam.module.ts
+++ b/src/app/shared-scam/shared-scam.module.ts
@@ -10,6 +10,10 @@ import { ScScam2Module } from './sc-scam2/sc-scam2.component';
     CommonModule,
     ScScam1Module,
     ScScam2Module,
+  ],
+  exports: [
+  	ScScam1Module,
+    ScScam2Module,
   ]
 })
 export class SharedScamModule { }


### PR DESCRIPTION
I think that your SCAM module contains one main error: you DON'T have to include the component in the bootstrap of the module, or it will be marked as an entrycomponent so it'll be always included in the build bundle!

I've fixed even your SharedScam module to be used as a group/re-export of scam module to simulate something like your FeatureModule1.

And then proved that even including the SharedScam in the main AppModule you will get all the scam component treeshaked from the main bundle until you use it in the app-component template

Let's try to merge this PR and play with it to see the result in the main-xxx.js bundle after ng build --prod to see if it works! 😸 